### PR TITLE
Fix IPFS plugin readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ datExample();
 ipfsExample();
 ```
 
-You can opt-into dat and IPFS support by installing the [webrun-plugin-dat](https://github.com/RangerMauve/webrun-plugin-dat) or [webrun-plugin-ipfs](https://github.com/RangerMauve/webrun-plugin-dat) modules.
+You can opt-into dat and IPFS support by installing the [webrun-plugin-dat](https://github.com/RangerMauve/webrun-plugin-dat) or [webrun-plugin-ipfs](https://github.com/RangerMauve/webrun-plugin-ipfs) modules.
 
 You can start a REPL using:
 


### PR DESCRIPTION
The IPFS webrun plugin link in the README currently points to the dat plugin.